### PR TITLE
Added link to HF dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Accompanying repository for the paper *Why do tree-based models still outperform
 ## Downloading the datasets
 
 To download these datasets, simply run `python data/download_data.py`.
+You can also find these datasets on [Hugging Face Hub](https://huggingface.co/datasets/inria-soda/tabular-benchmark).
 
 ## Training the models
 


### PR DESCRIPTION
Hello 🙌🏻

I created this dataset repository on Hugging Face Hub (and organization page for INRIA SODA along with it): https://huggingface.co/datasets/inria-soda/tabular-benchmark. We've discussed to have it linked to this repository previously with @GaelVaroquaux.

There are cool things that come with it: dataset widget in repository, the dataset card I filled according to the paper you've published, ability to stream any dataset in this benchmark without downloading them completely, loading a dataset with simple `dataset = load_dataset("inria-soda/tabular-benchmark", data_files="reg_cat/house_sales.csv")`. The datasets can also be loaded as pandas dataset (or other formats).

Please let me know if you'd like to be added to organization, so that you can make changes as you wish on the dataset. (or simply you can give me feedback and I can edit it 🙂)
